### PR TITLE
Node.js v10 Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ ENV REFRESHED_AT $REFRESHED_AT
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
-    nodejs \
-    yarn \
+  nodejs \
+  yarn \
   && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
-# Java (JRE 8) with Node.js 8 LTS Dockefile
+# Java (JRE 8) with Node.js 10 LTS Dockefile
 
 [![Docker Automated build](https://img.shields.io/docker/automated/timbru31/java-node.svg)](https://hub.docker.com/r/timbru31/java-node/)
 [![Docker Build Status](https://img.shields.io/docker/build/timbru31/java-node.svg)](https://hub.docker.com/r/timbru31/java-node/)
 [![Build Status](https://travis-ci.org/timbru31/docker-java-node.svg?branch=master)](https://travis-ci.org/timbru31/docker-java-node)
 
-A minimal Dockerfile based on OpenJDK's JRE8 Dockerfile (regular, slim or alpine) with Node.js 8 LTS (Carbon) installed
+A minimal Dockerfile based on OpenJDK's JRE8 Dockerfile (regular, slim or alpine) with Node.js 10 LTS (Carbon) installed
 
 ## What's included
 
-* JRE 8
-* Node.js 8
-* npm 5
-* yarn
+- JRE 8
+- Node.js 10
+- npm 6
+- yarn
 
 ---
+
 Built by (c) Tim Brust and contributors. Released under the MIT license.

--- a/slim/Dockerfile
+++ b/slim/Dockerfile
@@ -6,16 +6,16 @@ ENV REFRESHED_AT $REFRESHED_AT
 
 # hadolint ignore=DL3009
 RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
-    curl \
-    gnupg2
+  curl \
+  gnupg2
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
-    nodejs \
-    yarn \
+  nodejs \
+  yarn \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Node.js v10 will enter LTS on October 30, 2018. 

This upgrades Node.js v8 to v10 in this image. 

I'm somewhat new to the Docker ecosystem. I'm not sure if this should be versioned as to not break anyone downstream using the image. It'd be especially cool if you can specify which version of Node.js you'd want:

Ex. 

`FROM timbru31/java-node:8`
`FROM timbru31/java-node:10`

Happy to update the PR to something like this if it's possible. Just not exactly sure how 😄 