### PR TITLE
fix: use oldstable for node 20

### DIFF
--- a/11/jdk/20/alpine/Dockerfile
+++ b/11/jdk/20/alpine/Dockerfile
@@ -4,10 +4,13 @@ LABEL maintainer "Tim Brust <github@timbrust.de>"
 ARG REFRESHED_AT
 ENV REFRESHED_AT $REFRESHED_AT
 
-RUN apk -U upgrade \
+RUN echo @old-stable https://dl-cdn.alpinelinux.org/alpine/v3.20/community >> /etc/apk/repositories \
+  && echo @old-stable https://dl-cdn.alpinelinux.org/alpine/v3.20/main >> /etc/apk/repositories \
+  && apk -U upgrade \
   && apk add --no-cache \
-    nodejs \
-    npm \
+    ada-libs@old-stable \
+    nodejs@old-stable \
+    npm@old-stable \
     yarn \
     curl \
     git

--- a/11/jre/20/alpine/Dockerfile
+++ b/11/jre/20/alpine/Dockerfile
@@ -4,10 +4,13 @@ LABEL maintainer "Tim Brust <github@timbrust.de>"
 ARG REFRESHED_AT
 ENV REFRESHED_AT $REFRESHED_AT
 
-RUN apk -U upgrade \
+RUN echo @old-stable https://dl-cdn.alpinelinux.org/alpine/v3.20/community >> /etc/apk/repositories \
+  && echo @old-stable https://dl-cdn.alpinelinux.org/alpine/v3.20/main >> /etc/apk/repositories \
+  && apk -U upgrade \
   && apk add --no-cache \
-    nodejs \
-    npm \
+    ada-libs@old-stable \
+    nodejs@old-stable \
+    npm@old-stable \
     yarn \
     curl \
     git

--- a/17/jdk/20/alpine/Dockerfile
+++ b/17/jdk/20/alpine/Dockerfile
@@ -4,10 +4,13 @@ LABEL maintainer "Tim Brust <github@timbrust.de>"
 ARG REFRESHED_AT
 ENV REFRESHED_AT $REFRESHED_AT
 
-RUN apk -U upgrade \
+RUN echo @old-stable https://dl-cdn.alpinelinux.org/alpine/v3.20/community >> /etc/apk/repositories \
+  && echo @old-stable https://dl-cdn.alpinelinux.org/alpine/v3.20/main >> /etc/apk/repositories \
+  && apk -U upgrade \
   && apk add --no-cache \
-    nodejs \
-    npm \
+    ada-libs@old-stable \
+    nodejs@old-stable \
+    npm@old-stable \
     yarn \
     curl \
     git

--- a/17/jre/20/alpine/Dockerfile
+++ b/17/jre/20/alpine/Dockerfile
@@ -4,10 +4,13 @@ LABEL maintainer "Tim Brust <github@timbrust.de>"
 ARG REFRESHED_AT
 ENV REFRESHED_AT $REFRESHED_AT
 
-RUN apk -U upgrade \
+RUN echo @old-stable https://dl-cdn.alpinelinux.org/alpine/v3.20/community >> /etc/apk/repositories \
+  && echo @old-stable https://dl-cdn.alpinelinux.org/alpine/v3.20/main >> /etc/apk/repositories \
+  && apk -U upgrade \
   && apk add --no-cache \
-    nodejs \
-    npm \
+    ada-libs@old-stable \
+    nodejs@old-stable \
+    npm@old-stable \
     yarn \
     curl \
     git

--- a/21/jdk/20/alpine/Dockerfile
+++ b/21/jdk/20/alpine/Dockerfile
@@ -4,10 +4,13 @@ LABEL maintainer "Tim Brust <github@timbrust.de>"
 ARG REFRESHED_AT
 ENV REFRESHED_AT $REFRESHED_AT
 
-RUN apk -U upgrade \
+RUN echo @old-stable https://dl-cdn.alpinelinux.org/alpine/v3.20/community >> /etc/apk/repositories \
+  && echo @old-stable https://dl-cdn.alpinelinux.org/alpine/v3.20/main >> /etc/apk/repositories \
+  && apk -U upgrade \
   && apk add --no-cache \
-    nodejs \
-    npm \
+    ada-libs@old-stable \
+    nodejs@old-stable \
+    npm@old-stable \
     yarn \
     curl \
     git

--- a/21/jre/20/alpine/Dockerfile
+++ b/21/jre/20/alpine/Dockerfile
@@ -4,10 +4,13 @@ LABEL maintainer "Tim Brust <github@timbrust.de>"
 ARG REFRESHED_AT
 ENV REFRESHED_AT $REFRESHED_AT
 
-RUN apk -U upgrade \
+RUN echo @old-stable https://dl-cdn.alpinelinux.org/alpine/v3.20/community >> /etc/apk/repositories \
+  && echo @old-stable https://dl-cdn.alpinelinux.org/alpine/v3.20/main >> /etc/apk/repositories \
+  && apk -U upgrade \
   && apk add --no-cache \
-    nodejs \
-    npm \
+    ada-libs@old-stable \
+    nodejs@old-stable \
+    npm@old-stable \
     yarn \
     curl \
     git

--- a/8/jdk/20/alpine/Dockerfile
+++ b/8/jdk/20/alpine/Dockerfile
@@ -4,10 +4,13 @@ LABEL maintainer "Tim Brust <github@timbrust.de>"
 ARG REFRESHED_AT
 ENV REFRESHED_AT $REFRESHED_AT
 
-RUN apk -U upgrade \
+RUN echo @old-stable https://dl-cdn.alpinelinux.org/alpine/v3.20/community >> /etc/apk/repositories \
+  && echo @old-stable https://dl-cdn.alpinelinux.org/alpine/v3.20/main >> /etc/apk/repositories \
+  && apk -U upgrade \
   && apk add --no-cache \
-    nodejs \
-    npm \
+    ada-libs@old-stable \
+    nodejs@old-stable \
+    npm@old-stable \
     yarn \
     curl \
     git

--- a/8/jre/20/alpine/Dockerfile
+++ b/8/jre/20/alpine/Dockerfile
@@ -4,10 +4,13 @@ LABEL maintainer "Tim Brust <github@timbrust.de>"
 ARG REFRESHED_AT
 ENV REFRESHED_AT $REFRESHED_AT
 
-RUN apk -U upgrade \
+RUN echo @old-stable https://dl-cdn.alpinelinux.org/alpine/v3.20/community >> /etc/apk/repositories \
+  && echo @old-stable https://dl-cdn.alpinelinux.org/alpine/v3.20/main >> /etc/apk/repositories \
+  && apk -U upgrade \
   && apk add --no-cache \
-    nodejs \
-    npm \
+    ada-libs@old-stable \
+    nodejs@old-stable \
+    npm@old-stable \
     yarn \
     curl \
     git


### PR DESCRIPTION
This pull request updates several Dockerfiles to use older stable repositories for Alpine Linux and ensures the installation of packages from these repositories. The changes are applied to different versions of JDK and JRE Dockerfiles.

Updates to Alpine repositories and package installations:

* Added references to `old-stable` repositories in `11/jdk/20/alpine/Dockerfile` and updated the package installations to use these repositories.
* Added references to `old-stable` repositories in `11/jre/20/alpine/Dockerfile` and updated the package installations to use these repositories.
* Added references to `old-stable` repositories in `17/jdk/20/alpine/Dockerfile` and updated the package installations to use these repositories.
* Added references to `old-stable` repositories in `17/jre/20/alpine/Dockerfile` and updated the package installations to use these repositories.
* Added references to `old-stable` repositories in `21/jdk/20/alpine/Dockerfile` and updated the package installations to use these repositories.
* Added references to `old-stable` repositories in `21/jre/20/alpine/Dockerfile` and updated the package installations to use these repositories.
* Added references to `old-stable` repositories in `8/jdk/20/alpine/Dockerfile` and updated the package installations to use these repositories.
* Added references to `old-stable` repositories in `8/jre/20/alpine/Dockerfile` and updated the package installations to use these repositories.